### PR TITLE
Encoding fix after merge from cli

### DIFF
--- a/submerge-cli/src/main/java/com/github/dnbn/submerge/cli/CliService.java
+++ b/submerge-cli/src/main/java/com/github/dnbn/submerge/cli/CliService.java
@@ -178,7 +178,7 @@ public class CliService {
 		StrSubstitutor substitutor = new StrSubstitutor(substitutes);
 		finalName = substitutor.replace(finalName);
 
-		FileUtils.writeStringToFile(new File(finalName + ".ass"), ass.toString());
+		FileUtils.writeStringToFile(new File(finalName + ".ass", "UTF-8"), ass.toString());
 	}
 
 	/**


### PR DESCRIPTION
When I ran jar from command line on windows 10... the merged file had ANSI encoding.

If no set value it means platform default... so I think it is better to implicit set it to "UTF-8".
Or add new setting into resources.